### PR TITLE
Margin in the iPhone

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -150,6 +150,9 @@ h4 {
 body > section, body > footer {
   max-width: $width;
   margin: 0 auto;
+  @media #{$iphone-query} {
+    margin: 0 5px;
+  } 
 }
 
 // Header


### PR DESCRIPTION
Only a small adjustment to read better on the iPhone.
I always read the shownotes on the iPhone while watching the episode on the iPad. And with the margin so close to the screen it's difficult to read.
I made ​​the suggestion while on Twitter, but here goes! ;)

I'm not a frontend expert so maybe can be better.